### PR TITLE
Switch to official HtmlAgilityPack package

### DIFF
--- a/ReadSharp.Core/ReadSharp.Core.csproj
+++ b/ReadSharp.Core/ReadSharp.Core.csproj
@@ -18,7 +18,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MysticMind.HtmlAgilityPack" Version="1.0.0" />
+    <PackageReference Include="HtmlAgilityPack" Version="1.5.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
The HtmlAgilityPack supports .NET Standard as of version 1.5.