### PR TITLE
[PR] The proj files have been updated to enable SourceLink

### DIFF
--- a/ReadSharp.Core/ReadSharp.Core.csproj
+++ b/ReadSharp.Core/ReadSharp.Core.csproj
@@ -15,7 +15,15 @@
     <Copyright>2017</Copyright>
     <RepositoryType></RepositoryType>
     <RootNamespace>ReadSharp</RootNamespace>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
 
   <ItemGroup>
     <PackageReference Include="HtmlAgilityPack" Version="1.5.1" />

--- a/ReadSharp.Ports.NReadability.Core/ReadSharp.Ports.NReadability.Core.csproj
+++ b/ReadSharp.Ports.NReadability.Core/ReadSharp.Ports.NReadability.Core.csproj
@@ -13,7 +13,15 @@
     <RepositoryUrl>https://github.com/nieltg/ReadSharp.Core</RepositoryUrl>
     <Version>1.0.1</Version>
     <PackageId>ReadSharp.Ports.NReadability.Core</PackageId>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
 
   <ItemGroup>
     <EmbeddedResource Include="Resources\readability.css" />

--- a/ReadSharp.Ports.SgmlReader.Core/ReadSharp.Ports.SgmlReader.Core.csproj
+++ b/ReadSharp.Ports.SgmlReader.Core/ReadSharp.Ports.SgmlReader.Core.csproj
@@ -11,7 +11,15 @@
     <PackageProjectUrl>https://github.com/nieltg/ReadSharp.Core</PackageProjectUrl>
     <RepositoryUrl>https://github.com/nieltg/ReadSharp.Core</RepositoryUrl>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DefineConstants>TRACE;RELEASE;NETSTANDARD1_0;PORTABLE</DefineConstants>


### PR DESCRIPTION
CSProj files have been updated to enable SourceLink in your nuget
---

*[This pull request was created with an automated workflow]*

I noticed that your repository and Nuget package are important for our .NET community, but you still haven't enabled SourceLink.

**We have to take 2 steps:**
1) Please approve this pull request and make .NET a better place for .NET developers and their debugging.
2) **Then just upload the .snupkg file** to https://www.nuget.org/ (now you can find the snupkg file along with the .nuget file)

You can find more information about SourceLine at the following links  
https://github.com/dotnet/sourcelink
https://www.hanselman.com/blog/ExploringNETCoresSourceLinkSteppingIntoTheSourceCodeOfNuGetPackagesYouDontOwn.aspx

If you are interesting about this automated workflow and how it works  
https://github.com/JTOne123/GitHubMassUpdater

*If you notice any flaws, please comment and I will try to make fixes manually*
